### PR TITLE
Add workload annotations to namespace for SNO

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,8 +1,11 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Fix the following error when deploy in SNO:
"autoscaling.openshift.io/ManagementCPUsOverride the pod namespace
does not allow the workload type management"

Signed-off-by: Jack Ding <jacding@redhat.com>