### PR TITLE
Align kube-rbac-proxy image references

### DIFF
--- a/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
@@ -265,7 +265,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.10
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.10
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/manifests/stable/hw-event-proxy-operator.clusterserviceversion.yaml
+++ b/manifests/stable/hw-event-proxy-operator.clusterserviceversion.yaml
@@ -265,7 +265,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: quay.io/openshift/origin-kube-rbac-proxy:4.10
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -13,4 +13,8 @@ spec:
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.10
+  - name: cloud-event-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cloud-event-proxy:4.10


### PR DESCRIPTION
Updated kube-rbac-proxy image references to use the same image tag.
Also added cloud-event-proxy image to image-references file.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @jzding @nishant-parekh 