### PR TITLE
[release-4.10] Update Makefile to use fixed operator-sdk version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
+	hack/sync-manifests-for-art-build.sh
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
@@ -23,9 +23,7 @@ metadata:
     createdAt: "2022-02-15"
     description: This software manages the lifecycle of the hw-event-proxy container.
     olm.skipRange: '>=4.3.0-0 <4.10.0'
-
     operators.operatorframework.io/builder: operator-sdk-v1.10.1-ocp
-
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat
     repository: https://github.com/openshift/hw-event-proxy
@@ -243,9 +241,7 @@ spec:
           - watch
         serviceAccountName: hw-event-proxy-operator-controller-manager
       deployments:
-      - label:
-          control-plane: controller-manager
-        name: hw-event-proxy-operator-controller-manager
+      - name: hw-event-proxy-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/hack/sync-manifests-for-art-build.sh
+++ b/hack/sync-manifests-for-art-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+cp bundle/manifests/* manifests/stable
+mv manifests/stable/hw-event-proxy-operator.clusterserviceversion.yaml manifests/stable/bare-metal-event-relay.clusterserviceversion.yaml
+sed -i -e 's/name: hw-event-proxy-operator.v4.10.0/name: bare-metal-event-relay.v4.10.0/' \
+       -e 's/\(description:.*\) hw-event-proxy/\1 Baremetal Hardware Event Proxy/' \
+       -e 's/displayName: Hardware Event Proxy Operator/displayName: Bare Metal Event Relay/' \
+       manifests/stable/bare-metal-event-relay.clusterserviceversion.yaml

--- a/manifests/stable/bare-metal-event-relay.clusterserviceversion.yaml
+++ b/manifests/stable/bare-metal-event-relay.clusterserviceversion.yaml
@@ -23,9 +23,7 @@ metadata:
     createdAt: "2022-02-15"
     description: This software manages the lifecycle of the Baremetal Hardware Event Proxy container.
     olm.skipRange: '>=4.3.0-0 <4.10.0'
-
     operators.operatorframework.io/builder: operator-sdk-v1.10.1-ocp
-
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat
     repository: https://github.com/openshift/hw-event-proxy
@@ -243,9 +241,7 @@ spec:
           - watch
         serviceAccountName: hw-event-proxy-operator-controller-manager
       deployments:
-      - label:
-          control-plane: controller-manager
-        name: hw-event-proxy-operator-controller-manager
+      - name: hw-event-proxy-operator-controller-manager
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
Updated the Makefile to use a fixed operator-sdk version, as well as
to verify the cached tool is the expected version. This protects
against using a stale cached operator-sdk version from a different
release branch

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @nishant-parekh @jzding 