### PR TITLE
Add storageType and set default transportHost to HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ metadata:
 spec:
   nodeSelector: {}
   transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+  storageType: "example-storage-class"
 ```
 Here the transport is set to `hw-event-publisher-service` service in the `openshift-bare-metal-events` namespace.
+
+The `storageType` is for HTTP transport only. HTTP transport requires persistent storage for storing subscription data. The `storageType` must be set to the name of StorageClass providing the persist storage.
+
+If `transportHost` is missing or empty, the default transportHost `"http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"` is used. In this case a valid `storageType` is still required.
+
+A special storageType `emptyDir` is used for developers only. It provides ephemeral storage for HTTP transport and is used for developer testings.
 
 ### With AMQP Transport
 ```
@@ -52,7 +59,15 @@ spec:
 
 ### Create Secret for Redfish Authentication
 This operator needs a secret to be created to access Redfish Message Registry.
-The secret name and spec the operand expects are under the same namespace the operand is deployed on. For example:
+
+```
+oc -n openshift-bare-metal-events create secret generic redfish-basic-auth \
+  --from-literal=username=${BMC_USER} \
+  --from-literal=password=${BMC_PASSWORD} \
+  --from-literal=hostaddr=${BMC_HOST}
+```
+
+The secret is created under the same namespace as the operator. For example:
 ```
 apiVersion: v1
 kind: Secret

--- a/api/v1alpha1/hardwareevent_types.go
+++ b/api/v1alpha1/hardwareevent_types.go
@@ -32,7 +32,7 @@ type HardwareEventSpec struct {
 	// Example HTTP transport: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
 	// Example AMQP transport: "amqp://amq-router-service-name.amq-namespace.svc.cluster.local"
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Transport Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
-	TransportHost string `json:"transportHost"`
+	TransportHost string `json:"transportHost,omitempty"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=debug
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Level",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
@@ -45,6 +45,10 @@ type HardwareEventSpec struct {
 	// +kubebuilder:validation:Required
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Node Selector",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	NodeSelector map[string]string `json:"nodeSelector"`
+
+	// StorageType is the name of StorageClass providing persist storage used by HTTP transport to store subscription data
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	StorageType string `json:"storageType,omitempty"`
 }
 
 // HardwareEventStatus defines the observed state of HardwareEvent

--- a/bindata/hw-event-proxy/000-deployment.yaml
+++ b/bindata/hw-event-proxy/000-deployment.yaml
@@ -61,7 +61,7 @@ spec:
                   key: hostaddr
             - name: LOG_LEVEL
               value: "{{ .LogLevel }}"
-        - name: cloud-event-sidecar
+        - name: cloud-event-proxy
           image: {{ .SideCar }}
           imagePullPolicy: IfNotPresent
           args:
@@ -104,32 +104,30 @@ spec:
               readOnly: True
       volumes:
         - name: pubsubstore
-          {{ if not (hasPrefix "amqp" .EventTransportHost) }}
-          persistentVolumeClaim:
-            claimName: cloud-event-proxy-store
-          {{ else }}
+          {{ if or (eq .StorageType "emptyDir") (hasPrefix "amqp" .EventTransportHost) }}
           emptyDir: {}
+          {{ else }}
+          persistentVolumeClaim:
+            claimName: cloud-event-proxy-store-{{ .StorageType }}
           {{ end }}
         - name: hw-event-proxy-certs
           secret:
             secretName: hw-event-proxy-secret
+# special storageType "emptyDir" is used for developer tests to map pubsubstore volume to emptyDir
+{{ if (ne .StorageType "emptyDir") }}
 {{ if not (hasPrefix "amqp" .EventTransportHost) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: cloud-event-proxy-store
+  name: cloud-event-proxy-store-{{ .StorageType }}
   namespace: "{{ .Namespace }}"
 spec:
-  # By default use the (default) storageClass.
-  # Use the following command to patch a storageClass as default.
-  # oc patch storageclass example-storage-class -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-  # To use a specific storageClass, uncomment the following line and replace the place holder
-  # with the name of storage class.
-  # storageClassName: <storage-class-name>
+  storageClassName: {{ .StorageType }}
   resources:
     requests:
       storage: 10Mi
   accessModes:
   - ReadWriteOnce
+{{ end }}
 {{ end }}

--- a/bundle/manifests/event.redhat-cne.org_hardwareevents.yaml
+++ b/bundle/manifests/event.redhat-cne.org_hardwareevents.yaml
@@ -44,6 +44,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              storageType:
+                description: StorageType is the name of StorageClass providing persist
+                  storage used by HTTP transport to store subscription data
+                type: string
               transportHost:
                 description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
                   Example HTTP transport: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
@@ -51,7 +55,6 @@ spec:
                 type: string
             required:
             - nodeSelector
-            - transportHost
             type: object
           status:
             description: HardwareEventStatus defines the observed state of HardwareEvent

--- a/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/hw-event-proxy-operator.clusterserviceversion.yaml
@@ -14,6 +14,7 @@ metadata:
             "nodeSelector": {
               "node-role.kubernetes.io/worker": ""
             },
+            "storageType": "emptyDir",
             "transportHost": "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
           }
         }
@@ -58,6 +59,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Node Selector
         path: nodeSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: StorageType is the name of StorageClass providing persist storage
+          used by HTTP transport to store subscription data
+        displayName: Storage Type
+        path: storageType
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
@@ -115,18 +122,6 @@ spec:
         - apiGroups:
           - '*'
           resources:
-          - persistentvolumeclaims
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - '*'
-          resources:
           - services
           verbs:
           - create
@@ -178,6 +173,17 @@ spec:
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
           - watch
         - apiGroups:
           - ""
@@ -253,6 +259,14 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: hw-event-proxy-operator-controller-manager
       deployments:
       - label:
@@ -306,7 +320,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/openshift/origin-baremetal-hardware-event-proxy-operator:4.13.0
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/crd/bases/event.redhat-cne.org_hardwareevents.yaml
+++ b/config/crd/bases/event.redhat-cne.org_hardwareevents.yaml
@@ -45,6 +45,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              storageType:
+                description: StorageType is the name of StorageClass providing persist
+                  storage used by HTTP transport to store subscription data
+                type: string
               transportHost:
                 description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"
                   Example HTTP transport: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
@@ -52,7 +56,6 @@ spec:
                 type: string
             required:
             - nodeSelector
-            - transportHost
             type: object
           status:
             description: HardwareEventStatus defines the observed state of HardwareEvent

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,9 +31,11 @@ spec:
         - /hw-event-proxy-operator
         args:
         - --leader-elect
+        - --logtostderr
+        - --stderrthreshold=INFO
         image: controller
         name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/manifests/bases/hw-event-proxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/hw-event-proxy-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
               "node-role.kubernetes.io/worker": ""
             },
             "transportHost": "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+            "storageType": "example-storage-class"
           }
         }
       ]
@@ -56,6 +57,12 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: Node Selector
         path: nodeSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: StorageType is the name of StorageClass providing persist storage
+          used by HTTP transport to store subscription data
+        displayName: Storage Type
+        path: storageType
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'TransportHost format is <protocol>://<transport-service>.<namespace>.svc.cluster.local:<transport-port>"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,18 +8,6 @@ rules:
 - apiGroups:
   - '*'
   resources:
-  - persistentvolumeclaims
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
   - services
   verbs:
   - create
@@ -71,6 +59,17 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""
@@ -145,4 +144,12 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
   - watch

--- a/config/samples/event_v1alpha1_hardwareevent.yaml
+++ b/config/samples/event_v1alpha1_hardwareevent.yaml
@@ -6,3 +6,4 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+  storageType: emptyDir


### PR DESCRIPTION
This PR introduces a new field `storageType` in HardwareEvent spec. 
The `storageType` is for HTTP transport only. HTTP transport requires persistent storage for storing subscription data. The `storageType` must be set to the name of StorageClass providing the persist storage.

The example below assumes PVs are provisioned or will be dynamically provisioned by StorageClass named "example-storage-class".
```
kind: HardwareEvent
metadata:
  name: openshift-bare-metal-events
  namespace: openshift-bare-metal-events
spec:
  nodeSelector: {}
  transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
  storageType: "example-storage-class"
  logLevel: "trace"
```

Upon applying the above config, the hw-event-proxy-operator will create a PVC with name  `cloud-event-proxy-store-<storageType>`, and use value of `storageType` as StorageClassName.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: cloud-event-proxy-store-example-storage-class
  namespace: openshift-ptp
spec:
  storageClassName: example-storage-class
  resources:
    requests:
      storage: 10Mi
  accessModes:
  - ReadWriteOnce
```

If `transportHost` is missing or empty, the default transportHost `"http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"` is used. In this case a valid `storageType` is still required.

A special storageType `emptyDir` is used for developers only. It provides ephemeral storage for HTTP transport and is used for developer testings.

Error scenarios:

If HTTP transport is used but `storageType` is missing or empty, the `HardwareEvent` will fail to apply with the following error:
>for HTTP transport, storageType must be set to the name of StorageClass providing persist storage

If HTTP transport is used but `storageType` is not a valid storage class name, the `HardwareEvent` will fail to apply with the following error:
>storageType is set to StorageClass storage-class-foo which does not exist
